### PR TITLE
Added RGB8 pixel_format for colored visualization in rviz2

### DIFF
--- a/include/flir_spinnaker_common/pixel_format.h
+++ b/include/flir_spinnaker_common/pixel_format.h
@@ -23,7 +23,7 @@ namespace flir_spinnaker_common
 {
 namespace pixel_format
 {
-enum PixelFormat { INVALID = 0, BayerRG8, Mono8 };
+enum PixelFormat { INVALID = 0, BayerRG8, RGB8, Mono8 };
 std::string to_string(PixelFormat f);
 PixelFormat from_nodemap_string(const std::string pixFmt);
 }  // namespace pixel_format

--- a/src/pixel_format.cpp
+++ b/src/pixel_format.cpp
@@ -24,6 +24,9 @@ std::string to_string(PixelFormat f)
     case BayerRG8:
       return ("BayerRG8");
       break;
+    case RGB8:
+      return ("RGB8");
+      break;
     case Mono8:
       return ("Mono8");
       break;
@@ -38,7 +41,11 @@ PixelFormat from_nodemap_string(const std::string pixFmt)
 {
   if (pixFmt == "BayerRG8") {
     return (BayerRG8);
-  } else if (pixFmt == "Mono8") {
+  } 
+  else if (pixFmt == "RGB8"){
+    return RGB8;
+  } 
+  else if (pixFmt == "Mono8") {
     return (Mono8);
   } else {
     return (INVALID);


### PR DESCRIPTION
This PR adds support for the RGB8 pixel format. 

With the current BayerRG8 format, images in rviz2 are displayed as grayscale, even though they should be colored.

Additional changes to flir_spinnaker_ros2 should be made, I'll open another PR for that.